### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FormulaCLI
-Command Line Interface for easy access to latests F1 news and results. 
+Command Line Interface for easy access to latest F1 news and results. 
 
 Feel free to contribute in any way you can!
 


### PR DESCRIPTION
## Summary
- fix minor typo in README intro

## Testing
- `pip install requests`
- `pip install -r requirements.txt` *(fails: metadata generation failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6847a5b79188832d94adb3199bbd1737