### PR TITLE
Fix lazy imports and resize bug

### DIFF
--- a/formulacli/__init__.py
+++ b/formulacli/__init__.py
@@ -1,6 +1,18 @@
-"""
-    formulacli
-    ~~~~~~~~~~
+"""Utilities and lazy loading for the :mod:`formulacli` package."""
 
-"""
-from formulacli.app import FormulaCLI
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import importlib
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .app import FormulaCLI
+
+
+def __getattr__(name: str):
+    """Lazily import ``FormulaCLI`` to avoid heavy dependencies at import time."""
+    if name == "FormulaCLI":
+        module = importlib.import_module(".app", __name__)
+        return module.FormulaCLI
+    raise AttributeError(f"module {__name__!r} has no attribute {name}")
+

--- a/formulacli/img_converter.py
+++ b/formulacli/img_converter.py
@@ -86,7 +86,10 @@ def convert_image(
         image = image.crop(crop_box)
 
     if ratio and size:
-        image = image.resize(round(size[0] * ratio[0]), round(size[1] * ratio[1]))
+        image = image.resize((
+            round(size[0] * ratio[0]),
+            round(size[1] * ratio[1])
+        ))
     elif size:
         image = image.resize(size)
     elif ratio:


### PR DESCRIPTION
## Summary
- lazily import `FormulaCLI` to avoid heavy deps when package loads
- fix incorrect argument passing in `img_converter.resize`
- ensure tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a2b665a4832d88af885707652a92